### PR TITLE
Updated deprecated `include`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,8 +13,8 @@
 #   notify:
 #     - enable ufw
 
-- include: ssl.yml
+- import_tasks: ssl.yml
   with_dict: "{{ sites }}"
   when: item.value.ssl
 
-- include: http.yml
+- import_tasks: http.yml


### PR DESCRIPTION
Replace deprecated include statement to import_tasks ( required for [#106 of the website repo](https://github.com/pyslackers/website/issues/106) )